### PR TITLE
add python notebook examples

### DIFF
--- a/ipnb examples/myria examples.ipynb
+++ b/ipnb examples/myria examples.ipynb
@@ -1,0 +1,142 @@
+{
+ "metadata": {
+  "name": ""
+ },
+ "nbformat": 3,
+ "nbformat_minor": 0,
+ "worksheets": [
+  {
+   "cells": [
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "import myria\n",
+      "\n",
+      "#demo for some basic operations in myria library\n",
+      "\n",
+      "#make a connection to by constructing a MyriaConnection object\n",
+      "#arguments: \n",
+      "'''\n",
+      "    config file (None in this example)\n",
+      "    host name;\n",
+      "    port number;\n",
+      "    time out(time out for the connection)\n",
+      "'''\n",
+      "conn = myria.MyriaConnection(None, 'rest.myria.cs.washington.edu', 1776, None)\n",
+      "\n",
+      "#get a dictionary of the workers\n",
+      "workers = conn.workers()\n",
+      "print \"worker 0: \" + workers['1']\n",
+      "print \"worker 1: \" + workers['2']\n",
+      "print \"worker 2: \" + workers['3']\n",
+      "print '\\n'\n",
+      "\n",
+      "#get a list of workers that are alive\n",
+      "alive_workers = conn.workers_alive()\n",
+      "print \"alive worker ids: \" + str(alive_workers)\n",
+      "print '\\n'\n",
+      "\n",
+      "\n",
+      "#get a specific worker with it's id      //bug to fix: No JSON object could be decoded\n",
+      "#worker = conn.worker(1)\n",
+      "\n",
+      "\n",
+      "#get a list of datasets\n",
+      "datasets = conn.datasets()\n",
+      "first_set = datasets[0]\n",
+      "print \"first dataset: \"\n",
+      "print str(first_set)\n",
+      "print '\\n'\n",
+      "\n",
+      "#get one dataset named PlanktonCount\n",
+      "#a dataset is a dictionary, the with keys: 'created', 'numTuples', 'uri', 'queryId', 'relationKey', 'schema'\n",
+      "dataset = conn.dataset({\"userName\":\"public\",\"programName\":\"demo\",\"relationName\":\"PlanktonCount\"})\n",
+      "\n",
+      "#the dataset contains the following information:\n",
+      "#created time, number of tuples in the schema, uri, quiry id, relationkey and the schema\n",
+      "keys = dataset.keys();\n",
+      "print \"information contains in a datast: \" + str(keys)\n",
+      "print '\\n'\n",
+      "\n",
+      "#get the schema of a dataset\n",
+      "schema = dataset['schema']\n",
+      "print 'schema of the data set is: ' + str(schema)\n",
+      "print '\\n'\n",
+      "\n",
+      "#get a list of column names\n",
+      "column_names = schema['columnNames']\n",
+      "print \"column names: \" + str(column_names) \n",
+      "#get a list of column types\n",
+      "column_types = schema['columnTypes']\n",
+      "print \"column types: \" + str(column_types)\n",
+      "print '\\n'\n",
+      "\n",
+      "\n",
+      "\n",
+      "\n",
+      "\n"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "worker 0: aldebaran.cs.washington.edu:1778\n",
+        "worker 1: altair.cs.washington.edu:1778\n",
+        "worker 2: betelgeuse.cs.washington.edu:1778\n",
+        "\n",
+        "\n",
+        "alive worker ids: [40, 22, 67, 49, 12, 31, 20, 6, 27, 55, 68, 62, 19, 34, 13, 41, 48, 5, 28, 69, 33, 18, 42, 47, 25, 61, 56, 46, 70, 7, 53, 26, 36, 45, 8, 35, 63, 72, 54, 17, 2, 9, 51, 44, 37, 58, 64, 16, 71, 10, 52, 43, 30, 23, 15, 38, 29, 1, 57, 65, 24, 21, 14, 60, 3, 66, 32, 39, 11, 4, 50, 59]\n",
+        "\n",
+        "\n",
+        "first dataset: "
+       ]
+      },
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "\n",
+        "{u'created': u'2014-05-09T17:55:09.871-07:00', u'numTuples': -1, u'uri': u'http://rest.myria.cs.washington.edu:1776/dataset/user-Brendan/program-cosmo50/relation-cosmo50SelectedEdges', u'queryId': 6622, u'relationKey': {u'userName': u'Brendan', u'relationName': u'cosmo50SelectedEdges', u'programName': u'cosmo50'}, u'schema': {u'columnNames': [u'NowGroup', u'NowHalo', u'CurrentTime', u'CurrentGrp', u'CurrentHalo', u'NextTime', u'NextGrp', u'NextHalo', u'SharedParticlesCount', u'SharedDarkParticlesCount'], u'columnTypes': [u'INT_TYPE', u'INT_TYPE', u'INT_TYPE', u'INT_TYPE', u'INT_TYPE', u'INT_TYPE', u'INT_TYPE', u'INT_TYPE', u'INT_TYPE', u'INT_TYPE']}}\n",
+        "\n",
+        "\n",
+        "information contains in a datast: [u'created', u'numTuples', u'uri', u'queryId', u'relationKey', u'schema']\n",
+        "\n",
+        "\n",
+        "schema of the data set is: {u'columnNames': [u'Cruise', u'Phytoplankton'], u'columnTypes': [u'STRING_TYPE', u'LONG_TYPE']}\n",
+        "\n",
+        "\n",
+        "column names: [u'Cruise', u'Phytoplankton']\n",
+        "column types: [u'STRING_TYPE', u'LONG_TYPE']\n",
+        "\n",
+        "\n"
+       ]
+      }
+     ],
+     "prompt_number": 35
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [],
+     "language": "python",
+     "metadata": {},
+     "outputs": [],
+     "prompt_number": 19
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [],
+     "language": "python",
+     "metadata": {},
+     "outputs": []
+    }
+   ],
+   "metadata": {}
+  }
+ ]
+}


### PR DESCRIPTION
add python notebook examples for the myria-python client
library. demonstrate basic operations (make new connections, get
workers, get sets etc.) 

Link to NBViewer
       http://nbviewer.ipython.org/gist/HaoranHuang/cbcd25f495865a7b6b39

@billhowe  @dhalperi
