### PR TITLE
setup.py: add requests to setup_requires

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ dist/
 myria_python.egg-info/
 .idea
 .scripttest*txt
+requests-*.egg/

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,7 @@ setup(
     url='https://github.com/uwescience/myria',
     description='Python interface for Myria.',
     long_description=open('README.md').read(),
+    setup_requires=["requests"],
     # see https://stackoverflow.com/questions/18578439
     install_requires=["pip >= 1.5.6", "pyOpenSSL >= 0.14", "ndg-httpsclient",
                       "pyasn1", "requests", "requests_toolbelt",


### PR DESCRIPTION
See #16 and
http://stackoverflow.com/questions/27497470/setuptools-finds-wrong-package-during-install

Multiple hours of 100's of Google searches eventually took me to this
numpy thread:
    https://github.com/numpy/numpy/issues/2434#issuecomment-65252402
for which they had to add numpy to `setup_requires` AND `install_requires` to fix a similar issue. Doing
this with requests seems to have worked. However, I am somewhat
skeptical as posters on SO indicated they did not see our problem in the
first place.

I tried on my Mac as well as on Ubuntu (dbserver02), and am able to
install from a clean virtualenv on both systems.

Fix #16 for now.
