### PR TITLE
Initial implementation for higher-level Myria entities

### DIFF
--- a/myria/__init__.py
+++ b/myria/__init__.py
@@ -1,8 +1,8 @@
-version = "1.1-dev"
-
 from .connection import *
 from .errors import *
 from .relation import *
 from .query import *
 from .schema import *
 import cmd
+
+version = "1.1-dev"

--- a/myria/__init__.py
+++ b/myria/__init__.py
@@ -2,4 +2,7 @@ version = "1.1-dev"
 
 from .connection import *
 from .errors import *
+from .relation import *
+from .query import *
+from .schema import *
 import cmd

--- a/myria/__init__.py
+++ b/myria/__init__.py
@@ -5,4 +5,4 @@ from .query import *
 from .schema import *
 import cmd
 
-version = "1.1-dev"
+version = "1.2-dev"

--- a/myria/plans.py
+++ b/myria/plans.py
@@ -1,0 +1,38 @@
+from functools import partial
+
+def get_parallel_import_plan(schema, work, relation, text='', 
+                             scan_metadata={}, insert_metadata={}, 
+                             scan_type='FileScan', insert_type='DbInsert'):
+   return \
+      { "fragments": map(partial(_get_parallel_import_fragment, [0], schema, relation, 
+                                 scan_type, insert_type,
+                                 scan_metadata, insert_metadata), work),
+        "logicalRa": text, 
+        "rawQuery":  text }
+
+def _get_parallel_import_fragment(taskid, schema, relation, scan_type, insert_type,
+                                  scan_metadata, insert_metadata, (worker, datasource)):
+  return { "overrideWorkers": [worker],
+           "operators":[
+               dict({
+                  "opId": __increment(taskid),
+                  "opType": scan_type,
+
+                  "schema": schema.toJson(),
+                  "source": datasource
+               }.items() + scan_metadata.items()),
+               dict({
+                  "opId": __increment(taskid),
+                  "opType": insert_type,
+
+                  "argChild": taskid[0]-1,
+                  "argOverwriteTable": True,
+
+                  "relationKey": relation
+                }.items() + insert_metadata.items())
+             ]
+          }
+
+def __increment(id):
+  id[0] += 1
+  return id[0] - 1

--- a/myria/plans.py
+++ b/myria/plans.py
@@ -31,9 +31,11 @@ def get_parallel_import_plan(schema, work, relation, text='',
 def _get_parallel_import_fragment(taskid, schema, relation,
                                   scan_type, insert_type,
                                   scan_metadata, insert_metadata,
-                                  (worker, datasource)):
+                                  assignment):
     """ Generate a single fragment of the parallel import plan """
-    return {"overrideWorkers": [worker],
+    worker_id = assignment[0]
+    datasource = assignment[1]
+    return {"overrideWorkers": [worker_id],
             "operators": [
                 dict({
                      "opId": __increment(taskid),

--- a/myria/plans.py
+++ b/myria/plans.py
@@ -53,8 +53,7 @@ def _get_parallel_import_fragment(taskid, schema, relation,
 
                      "relationKey": relation
                      }.items() + (insert_metadata or {}).items())
-              ]
-            }
+              ]}
 
 
 def __increment(value):

--- a/myria/plans.py
+++ b/myria/plans.py
@@ -2,6 +2,7 @@
 
 from functools import partial
 
+
 def get_parallel_import_plan(schema, work, relation, text='',
                              scan_metadata=None, insert_metadata=None,
                              scan_type='FileScan', insert_type='DbInsert'):
@@ -24,7 +25,8 @@ def get_parallel_import_plan(schema, work, relation, text='',
                                   scan_type, insert_type,
                                   scan_metadata, insert_metadata), work),
          "logicalRa": text,
-         "rawQuery":  text}
+         "rawQuery": text}
+
 
 def _get_parallel_import_fragment(taskid, schema, relation,
                                   scan_type, insert_type,
@@ -32,25 +34,26 @@ def _get_parallel_import_fragment(taskid, schema, relation,
                                   (worker, datasource)):
     """ Generate a single fragment of the parallel import plan """
     return {"overrideWorkers": [worker],
-            "operators":[
+            "operators": [
                 dict({
-                   "opId": __increment(taskid),
-                   "opType": scan_type,
+                     "opId": __increment(taskid),
+                     "opType": scan_type,
 
-                   "schema": schema.to_json(),
-                   "source": datasource
-                }.items() + (scan_metadata or {}).items()),
+                     "schema": schema.to_json(),
+                     "source": datasource
+                     }.items() + (scan_metadata or {}).items()),
                 dict({
-                   "opId": __increment(taskid),
-                   "opType": insert_type,
+                     "opId": __increment(taskid),
+                     "opType": insert_type,
 
-                   "argChild": taskid[0]-1,
-                   "argOverwriteTable": True,
+                     "argChild": taskid[0] - 1,
+                     "argOverwriteTable": True,
 
-                   "relationKey": relation
-                 }.items() + (insert_metadata or {}).items())
+                     "relationKey": relation
+                     }.items() + (insert_metadata or {}).items())
               ]
            }
+
 
 def __increment(value):
     value[0] += 1

--- a/myria/plans.py
+++ b/myria/plans.py
@@ -52,7 +52,7 @@ def _get_parallel_import_fragment(taskid, schema, relation,
                      "relationKey": relation
                      }.items() + (insert_metadata or {}).items())
               ]
-           }
+            }
 
 
 def __increment(value):

--- a/myria/plans.py
+++ b/myria/plans.py
@@ -3,9 +3,13 @@
 from functools import partial
 
 
+DEFAULT_SCAN_TYPE = 'FileScan'
+DEFAULT_INSERT_TYPE = 'DbInsert'
+
+
 def get_parallel_import_plan(schema, work, relation, text='',
-                             scan_metadata=None, insert_metadata=None,
-                             scan_type='FileScan', insert_type='DbInsert'):
+                             scan_parameters=None, insert_parameters=None,
+                             scan_type=None, insert_type=None):
     """ Generate a valid JSON Myria plan for parallel import of data
 
     work: list of (worker-id, data-source) pairs; data-source should be a
@@ -14,8 +18,8 @@ def get_parallel_import_plan(schema, work, relation, text='',
 
     Keyword arguments:
       text: description of the plan
-      scan_metadata: dict of additional operator parameters for the scan
-      insert_metadata: dict of additional operator parameters for the insertion
+      scan_parameters: dict of additional operator parameters for the scan
+      insert_parameters: dict of additional operator parameters for insertion
       scan_type: type of scan to perform
       insert_Type: type of insert to perform
     """
@@ -23,14 +27,14 @@ def get_parallel_import_plan(schema, work, relation, text='',
         {"fragments": map(partial(_get_parallel_import_fragment, [0],
                                   schema, relation,
                                   scan_type, insert_type,
-                                  scan_metadata, insert_metadata), work),
+                                  scan_parameters, insert_parameters), work),
          "logicalRa": text,
          "rawQuery": text}
 
 
 def _get_parallel_import_fragment(taskid, schema, relation,
                                   scan_type, insert_type,
-                                  scan_metadata, insert_metadata,
+                                  scan_parameters, insert_parameters,
                                   assignment):
     """ Generate a single fragment of the parallel import plan """
     worker_id = assignment[0]
@@ -39,20 +43,20 @@ def _get_parallel_import_fragment(taskid, schema, relation,
             "operators": [
                 dict({
                      "opId": __increment(taskid),
-                     "opType": scan_type,
+                     "opType": scan_type or DEFAULT_SCAN_TYPE,
 
                      "schema": schema.to_json(),
                      "source": datasource
-                     }.items() + (scan_metadata or {}).items()),
+                     }.items() + (scan_parameters or {}).items()),
                 dict({
                      "opId": __increment(taskid),
-                     "opType": insert_type,
+                     "opType": insert_type or DEFAULT_INSERT_TYPE,
 
                      "argChild": taskid[0] - 2,
                      "argOverwriteTable": True,
 
                      "relationKey": relation
-                     }.items() + (insert_metadata or {}).items())]}
+                     }.items() + (insert_parameters or {}).items())]}
 
 
 def __increment(value):

--- a/myria/plans.py
+++ b/myria/plans.py
@@ -48,7 +48,7 @@ def _get_parallel_import_fragment(taskid, schema, relation,
                      "opId": __increment(taskid),
                      "opType": insert_type,
 
-                     "argChild": taskid[0] - 1,
+                     "argChild": taskid[0] - 2,
                      "argOverwriteTable": True,
 
                      "relationKey": relation

--- a/myria/plans.py
+++ b/myria/plans.py
@@ -52,8 +52,7 @@ def _get_parallel_import_fragment(taskid, schema, relation,
                      "argOverwriteTable": True,
 
                      "relationKey": relation
-                     }.items() + (insert_metadata or {}).items())
-              ]}
+                     }.items() + (insert_metadata or {}).items())]}
 
 
 def __increment(value):

--- a/myria/query.py
+++ b/myria/query.py
@@ -1,7 +1,9 @@
+""" Higher-level types for interacting with Myria queries """
+
 import time
 import requests
-from . import MyriaRelation
 import myria.plans
+from myria.relation import MyriaRelation
 
 
 class MyriaQuery(object):

--- a/myria/query.py
+++ b/myria/query.py
@@ -32,7 +32,9 @@ class MyriaQuery(object):
                           connection, timeout)
 
     @staticmethod
-    def parallel_import(relation, work, timeout=3600):
+    def parallel_import(relation, work, timeout=3600,
+                        scan_type=None, scan_parameters=None,
+                        insert_type=None, insert_parameters=None):
         """ Submit a new parallel ingest plan to Myria
 
         relation: a MyriaRelation instance that receives the imported data
@@ -47,7 +49,9 @@ class MyriaQuery(object):
                 relation.schema,
                 [(wid, {"dataType": "URI", "uri": uri}) for wid, uri in work],
                 relation.qualified_name,
-                text='Parallel Import ' + str(work)),
+                text='Parallel Import ' + str(work),
+                scan_type=scan_type, scan_parameters=scan_parameters,
+                insert_type=insert_type, insert_parameters=insert_parameters),
             relation.connection,
             timeout)
 

--- a/myria/query.py
+++ b/myria/query.py
@@ -4,68 +4,97 @@ from . import MyriaRelation
 import myria.plans
 
 class MyriaQuery(object):
-  nonterminal_states = ['ACCEPTED', 'RUNNING']
+    """ Represents a Myria query """
 
-  def __init__(self, id, connection=MyriaRelation.DefaultConnection, timeout=60, *args, **kwargs):
-    self.id = id
-    self.connection = connection
-    self.timeout = timeout
-    self._status = None
+    nonterminal_states = ['ACCEPTED', 'RUNNING']
 
-    if kwargs.get('waitForCompletion', False): self.waitForCompletion()
+    def __init__(self, query_id, connection=MyriaRelation.DefaultConnection,
+                 timeout=60, wait_for_completion=False):
+        self.query_id = query_id
+        self.connection = connection
+        self.timeout = timeout
+        self._status = None
+        self._name = None
+        self._components = None
+        self._qualified_name = None
 
-  @staticmethod
-  def submit_plan(plan, connection=MyriaRelation.DefaultConnection, timeout=60):
-    return MyriaQuery(connection.submit_query(plan)['queryId'], connection)
+        if wait_for_completion:
+            self.wait_for_completion()
 
-  @staticmethod
-  def parallel_import(relation, uris, timeout=3600):
-    return MyriaQuery.submit_plan(
-      myria.plans.get_parallel_import_plan(relation.schema, 
-        map(lambda (id, uri): (id, { "dataType": "URI", "uri": uri }), uris), 
-        relation.qualified_name, 
-        text='Parallel Import ' + str(uris)),
-      relation.connection,
-      timeout)
+    @staticmethod
+    def submit_plan(plan, connection=MyriaRelation.DefaultConnection,
+                    timeout=60):
+        """ Submit a given plan to Myria and return a new query instance """
+        return MyriaQuery(connection.submit_query(plan)['queryId'],
+                          connection, timeout)
 
-  @property
-  def name(self):
-    self.waitForCompletion()
-    return self._name
-  
-  @property
-  def qualified_name(self):
-    self.waitForCompletion()
-    return self._qualified_name
+    @staticmethod
+    def parallel_import(relation, work, timeout=3600):
+        """ Submit a new parallel ingest plan to Myria
 
-  @property
-  def components(self):
-    self.waitForCompletion()
-    return self._components
+        relation: a MyriaRelation instance that receives the imported data
+        work: a sequence of (worker-id, uri) pairs assigning input to
+              each worker.  Each uri may have any supported scheme (e.g.,
+              file, http, hdfs) and any combination may be assigned to workers.
+              For local file URIs (file://foo/bar), the file is assumed to
+              be local (or locally accessible).
+        """
+        return MyriaQuery.submit_plan(
+          myria.plans.get_parallel_import_plan(relation.schema,
+            [(wid, {"dataType": "URI", "uri": uri}) for wid, uri in work],
+            relation.qualified_name,
+            text='Parallel Import ' + str(work)),
+          relation.connection,
+          timeout)
 
-  @property
-  def status(self):
-    if not self._status or self._status in self.nonterminal_states:
-      self._status = self.connection.get_query_status(self.id)['status']
-    return self._status
+    @property
+    def name(self):
+        """ The name assigned to this query, if any """
+        self.wait_for_completion()
+        return self._name
 
-  def toJson(self):
-    self.waitForCompletion()
-    return self.connection.download_dataset(self.qualified_name)
+    @property
+    def qualified_name(self):
+        """ A Myria-compatible dict representing the qualified name """
+        self.wait_for_completion()
+        return self._qualified_name
 
-  def waitForCompletion(self, timeout=None):
-    end = time.time() + (timeout or self.timeout)
-    while self.status in self.nonterminal_states:
-      if time.time() >= end: 
-        raise requests.Timeout()
-      time.sleep(1)
-    self.__on_completed()
+    @property
+    def components(self):
+        """ A list of the components [user, program, name] for the query """
+        self.wait_for_completion()
+        return self._components
 
-  def __on_completed(self):
-    dataset = self.connection._wrap_get('/dataset', params={'queryId': self.id})
-    if len(dataset):
-      self._qualified_name = dataset[0]['relationKey']
-      self._name = MyriaRelation._get_name(self._qualified_name)
-      self._components = MyriaRelation._get_name_components(self._name)
-    else:
-      raise AttributeError('Unable to load query metadata (query status={})'.format(self.status))
+    @property
+    def status(self):
+        """ The current status of the query """
+        if not self._status or self._status in self.nonterminal_states:
+            self._status = self.connection.get_query_status(
+                             self.query_id)['status']
+        return self._status
+
+    def to_json(self):
+        """ Download the JSON results of the query """
+        self.wait_for_completion()
+        return self.connection.download_dataset(self.qualified_name)
+
+    def wait_for_completion(self, timeout=None):
+        """ Wait up to <timeout> seconds for the query to complete """
+        end = time.time() + (timeout or self.timeout)
+        while self.status in self.nonterminal_states:
+            if time.time() >= end:
+                raise requests.Timeout()
+            time.sleep(1)
+        self._on_completed()
+
+    def _on_completed(self):
+        """ Load query metadata after completion """
+        dataset = self.connection._wrap_get('/dataset',
+                                            params={'queryId': self.query_id})
+        if len(dataset):
+            self._qualified_name = dataset[0]['relationKey']
+            self._name = MyriaRelation._get_name(self._qualified_name)
+            self._components = MyriaRelation._get_name_components(self._name)
+        else:
+            raise AttributeError('Unable to load query metadata '
+                                 '(query status={})'.format(self.status))

--- a/myria/query.py
+++ b/myria/query.py
@@ -3,6 +3,7 @@ import requests
 from . import MyriaRelation
 import myria.plans
 
+
 class MyriaQuery(object):
     """ Represents a Myria query """
 
@@ -40,12 +41,13 @@ class MyriaQuery(object):
               be local (or locally accessible).
         """
         return MyriaQuery.submit_plan(
-          myria.plans.get_parallel_import_plan(relation.schema,
-            [(wid, {"dataType": "URI", "uri": uri}) for wid, uri in work],
-            relation.qualified_name,
-            text='Parallel Import ' + str(work)),
-          relation.connection,
-          timeout)
+            myria.plans.get_parallel_import_plan(
+                relation.schema,
+                [(wid, {"dataType": "URI", "uri": uri}) for wid, uri in work],
+                relation.qualified_name,
+                text='Parallel Import ' + str(work)),
+            relation.connection,
+            timeout)
 
     @property
     def name(self):
@@ -70,7 +72,7 @@ class MyriaQuery(object):
         """ The current status of the query """
         if not self._status or self._status in self.nonterminal_states:
             self._status = self.connection.get_query_status(
-                             self.query_id)['status']
+                self.query_id)['status']
         return self._status
 
     def to_json(self):

--- a/myria/query.py
+++ b/myria/query.py
@@ -92,7 +92,7 @@ class MyriaQuery(object):
         self._on_completed()
 
     def _on_completed(self):
-        """ Load query metadata after completion """
+        """ Load query metadata after query completion """
         dataset = self.connection._wrap_get('/dataset',
                                             params={'queryId': self.query_id})
         if len(dataset):

--- a/myria/query.py
+++ b/myria/query.py
@@ -1,0 +1,71 @@
+import time
+import requests
+from . import MyriaRelation
+import myria.plans
+
+class MyriaQuery(object):
+  nonterminal_states = ['ACCEPTED', 'RUNNING']
+
+  def __init__(self, id, connection=MyriaRelation.DefaultConnection, timeout=60, *args, **kwargs):
+    self.id = id
+    self.connection = connection
+    self.timeout = timeout
+    self._status = None
+
+    if kwargs.get('waitForCompletion', False): self.waitForCompletion()
+
+  @staticmethod
+  def submit_plan(plan, connection=MyriaRelation.DefaultConnection, timeout=60):
+    return MyriaQuery(connection.submit_query(plan)['queryId'], connection)
+
+  @staticmethod
+  def parallel_import(relation, uris, timeout=3600):
+    return MyriaQuery.submit_plan(
+      myria.plans.get_parallel_import_plan(relation.schema, 
+        map(lambda (id, uri): (id, { "dataType": "URI", "uri": uri }), uris), 
+        relation.qualified_name, 
+        text='Parallel Import ' + str(uris)),
+      relation.connection,
+      timeout)
+
+  @property
+  def name(self):
+    self.waitForCompletion()
+    return self._name
+  
+  @property
+  def qualified_name(self):
+    self.waitForCompletion()
+    return self._qualified_name
+
+  @property
+  def components(self):
+    self.waitForCompletion()
+    return self._components
+
+  @property
+  def status(self):
+    if not self._status or self._status in self.nonterminal_states:
+      self._status = self.connection.get_query_status(self.id)['status']
+    return self._status
+
+  def toJson(self):
+    self.waitForCompletion()
+    return self.connection.download_dataset(self.qualified_name)
+
+  def waitForCompletion(self, timeout=None):
+    end = time.time() + (timeout or self.timeout)
+    while self.status in self.nonterminal_states:
+      if time.time() >= end: 
+        raise requests.Timeout()
+      time.sleep(1)
+    self.__on_completed()
+
+  def __on_completed(self):
+    dataset = self.connection._wrap_get('/dataset', params={'queryId': self.id})
+    if len(dataset):
+      self._qualified_name = dataset[0]['relationKey']
+      self._name = MyriaRelation._get_name(self._qualified_name)
+      self._components = MyriaRelation._get_name_components(self._name)
+    else:
+      raise AttributeError('Unable to load query metadata (query status={})'.format(self.status))

--- a/myria/relation.py
+++ b/myria/relation.py
@@ -40,7 +40,7 @@ class MyriaRelation(object):
     def to_json(self):
         """ Download this relation as JSON """
         return self.connection.download_dataset(self.qualified_name) \
-            if self.is_persisted else None
+            if self.is_persisted else []
 
     @property
     def schema(self):

--- a/myria/relation.py
+++ b/myria/relation.py
@@ -1,7 +1,9 @@
+""" Higher-level types for interacting with Myria relations """
+
 from dateutil.parser import parse
 from itertools import izip
 from myria import MyriaConnection, MyriaError
-from schema import MyriaSchema
+from myria.schema import MyriaSchema
 
 
 class MyriaRelation(object):

--- a/myria/relation.py
+++ b/myria/relation.py
@@ -34,12 +34,13 @@ class MyriaRelation(object):
         self._metadata = None
 
         if self._schema is not None and self.is_persisted:
-            raise MyriaError('New relation specified (schema != None), '
+            raise ValueError('New relation specified (schema != None), '
                              ' but it already exists on the server.')
 
     def to_json(self):
         """ Download this relation as JSON """
-        return self.connection.download_dataset(self.qualified_name)
+        return self.connection.download_dataset(self.qualified_name) \
+            if self.is_persisted else None
 
     @property
     def schema(self):

--- a/myria/relation.py
+++ b/myria/relation.py
@@ -30,12 +30,16 @@ class MyriaRelation(object):
         self.components = self._get_name_components(self.name)
         self.connection = connection
         self.qualified_name = self._get_qualified_name(self.components)
-        self._schema = schema
+        self._schema = None
         self._metadata = None
 
-        if self._schema is not None and self.is_persisted:
-            raise ValueError('New relation specified (schema != None), '
-                             ' but it already exists on the server.')
+        # If the relation is already persisted, any schema parameter
+        # must match the persisted version.
+        if schema is not None and self.is_persisted and self.schema != schema:
+            raise ValueError('Stored relation schema does not match '
+                             'that specified as schema parameter.')
+        elif schema is not None:
+            self._schema = schema
 
     def to_json(self):
         """ Download this relation as JSON """

--- a/myria/relation.py
+++ b/myria/relation.py
@@ -24,7 +24,7 @@ class MyriaRelation(object):
         schema: for a relation that does not yet exist, specify its schema
         """
         self.name = relation if isinstance(relation, basestring) \
-                    else relation.name
+            else relation.name
         self.components = self._get_name_components(self.name)
         self.connection = connection
         self.qualified_name = self._get_qualified_name(self.components)

--- a/myria/relation.py
+++ b/myria/relation.py
@@ -1,0 +1,71 @@
+from dateutil.parser import parse
+from itertools import izip
+from myria import MyriaConnection, MyriaError
+from schema import MyriaSchema
+
+class MyriaRelation(object):
+  DefaultConnection = MyriaConnection(hostname='localhost', port=8753)
+
+  # MyriaRelation({'userName': 'public', 'programName': 'adhoc', 'relationName': 'relation'})
+  # or
+  # MyriaRelation('public:adhoc:relation')
+  # or
+  # MyriaRelation('relation') # Defaults are 'public' and 'adhoc'
+  def __init__(self, relation, connection=DefaultConnection, *args, **kwargs):
+    self.name = relation if isinstance(relation, basestring) else relation.name
+    self.components = self._get_name_components(self.name)
+    self.connection = connection
+    self.qualified_name = self._get_qualified_name(self.components)
+    self._schema = kwargs['schema'] if 'schema' in kwargs else None
+
+    # Should probably expose a better way of creating "new" relations
+    if not self._schema is None and self._has_metadata:
+      raise MyriaError('New relation specified (schema != None), but it already exists on the server.')
+
+  def toJson(self):
+    return self.connection.download_dataset(self.qualified_name)
+
+  @property 
+  def schema(self):
+    if self._schema is None:
+      self._schema = MyriaSchema(json=self._metadata['schema'])
+    return self._schema
+
+  @property
+  def createdDate(self):
+    return parse(self._metadata['created'])
+
+  def __len__(self):
+    return int(self._metadata['numTuples'])
+
+  @property
+  def _metadata(self):
+    if 'metadata' not in self.__dict__:
+      self.metadata = self.connection.dataset(self.qualified_name)
+    return self.metadata
+
+  @property 
+  def _has_metadata(self):
+    try:
+      return bool(self._metadata)
+    except MyriaError:
+      return False
+
+  @staticmethod
+  def _get_name(qualified_name):
+    return ':'.join([qualified_name['userName'], 
+                     qualified_name['programName'], 
+                     qualified_name['relationName']])
+
+  @staticmethod
+  def _get_name_components(name):
+    components = name.split(':')
+    default_components = ['public', 'adhoc'][:max(3 - len(components), 0)]
+    return default_components + components[:3]
+
+  @staticmethod
+  def _get_qualified_name(name_or_components):
+    if isinstance(name_or_components, basestring):
+      return MyriaRelation._get_qualified_name(MyriaRelation._get_name_components(name_or_components))
+    else:
+      return dict(izip(('userName', 'programName', 'relationName'), name_or_components[:3]))

--- a/myria/relation.py
+++ b/myria/relation.py
@@ -3,17 +3,12 @@ from itertools import izip
 from myria import MyriaConnection, MyriaError
 from schema import MyriaSchema
 
+
 class MyriaRelation(object):
     """ Represents a relation in the Myria system """
 
     DefaultConnection = MyriaConnection(hostname='localhost', port=8753)
 
-    # MyriaRelation({'userName': 'public', 'programName': 'adhoc',
-        #'relationName': 'relation'})
-    # or
-    # MyriaRelation('public:adhoc:relation')
-    # or
-    # MyriaRelation('relation') # Defaults are 'public' and 'adhoc'
     def __init__(self, relation, connection=DefaultConnection, schema=None):
         """ Attach to an existing Myria relation, or create a new one
 
@@ -29,14 +24,14 @@ class MyriaRelation(object):
         schema: for a relation that does not yet exist, specify its schema
         """
         self.name = relation if isinstance(relation, basestring) \
-                             else relation.name
+                    else relation.name
         self.components = self._get_name_components(self.name)
         self.connection = connection
         self.qualified_name = self._get_qualified_name(self.components)
         self._schema = schema
         self._metadata = None
 
-        if not self._schema is None and self.is_persisted:
+        if self._schema is not None and self.is_persisted:
             raise MyriaError('New relation specified (schema != None), '
                              ' but it already exists on the server.')
 
@@ -94,7 +89,7 @@ class MyriaRelation(object):
         """ Generate a Myria relation dictionary from a string or list """
         if isinstance(name_or_components, basestring):
             return MyriaRelation._get_qualified_name(
-                     MyriaRelation._get_name_components(name_or_components))
+                MyriaRelation._get_name_components(name_or_components))
         else:
             return dict(izip(('userName', 'programName', 'relationName'),
                              name_or_components[:3]))

--- a/myria/relation.py
+++ b/myria/relation.py
@@ -4,68 +4,97 @@ from myria import MyriaConnection, MyriaError
 from schema import MyriaSchema
 
 class MyriaRelation(object):
-  DefaultConnection = MyriaConnection(hostname='localhost', port=8753)
+    """ Represents a relation in the Myria system """
 
-  # MyriaRelation({'userName': 'public', 'programName': 'adhoc', 'relationName': 'relation'})
-  # or
-  # MyriaRelation('public:adhoc:relation')
-  # or
-  # MyriaRelation('relation') # Defaults are 'public' and 'adhoc'
-  def __init__(self, relation, connection=DefaultConnection, *args, **kwargs):
-    self.name = relation if isinstance(relation, basestring) else relation.name
-    self.components = self._get_name_components(self.name)
-    self.connection = connection
-    self.qualified_name = self._get_qualified_name(self.components)
-    self._schema = kwargs['schema'] if 'schema' in kwargs else None
+    DefaultConnection = MyriaConnection(hostname='localhost', port=8753)
 
-    # Should probably expose a better way of creating "new" relations
-    if not self._schema is None and self._has_metadata:
-      raise MyriaError('New relation specified (schema != None), but it already exists on the server.')
+    # MyriaRelation({'userName': 'public', 'programName': 'adhoc',
+        #'relationName': 'relation'})
+    # or
+    # MyriaRelation('public:adhoc:relation')
+    # or
+    # MyriaRelation('relation') # Defaults are 'public' and 'adhoc'
+    def __init__(self, relation, connection=DefaultConnection, schema=None):
+        """ Attach to an existing Myria relation, or create a new one
 
-  def toJson(self):
-    return self.connection.download_dataset(self.qualified_name)
+        relation: the name of the relation.  One of:
+           * qualified components: {'userName': 'public',
+                                    'programName': 'adhoc',
+                                    'relationName': 'my_relation'}
+           * qualified name:       'public:adhoc:my_relation'
+           * unqualified name:     'my_relation' (assume public:adhoc)
 
-  @property 
-  def schema(self):
-    if self._schema is None:
-      self._schema = MyriaSchema(json=self._metadata['schema'])
-    return self._schema
+        Keyword arguments:
+        connection: attach to a specific Myria API endpoint
+        schema: for a relation that does not yet exist, specify its schema
+        """
+        self.name = relation if isinstance(relation, basestring) \
+                             else relation.name
+        self.components = self._get_name_components(self.name)
+        self.connection = connection
+        self.qualified_name = self._get_qualified_name(self.components)
+        self._schema = schema
+        self._metadata = None
 
-  @property
-  def createdDate(self):
-    return parse(self._metadata['created'])
+        if not self._schema is None and self.is_persisted:
+            raise MyriaError('New relation specified (schema != None), '
+                             ' but it already exists on the server.')
 
-  def __len__(self):
-    return int(self._metadata['numTuples'])
+    def to_json(self):
+        """ Download this relation as JSON """
+        return self.connection.download_dataset(self.qualified_name)
 
-  @property
-  def _metadata(self):
-    if 'metadata' not in self.__dict__:
-      self.metadata = self.connection.dataset(self.qualified_name)
-    return self.metadata
+    @property
+    def schema(self):
+        """ The schema of the relation """
+        if self._schema is None:
+            self._schema = MyriaSchema(json=self.metadata['schema'])
+        return self._schema
 
-  @property 
-  def _has_metadata(self):
-    try:
-      return bool(self._metadata)
-    except MyriaError:
-      return False
+    @property
+    def created_date(self):
+        """ The creation date for this relation """
+        return parse(self.metadata['created'])
 
-  @staticmethod
-  def _get_name(qualified_name):
-    return ':'.join([qualified_name['userName'], 
-                     qualified_name['programName'], 
-                     qualified_name['relationName']])
+    def __len__(self):
+        """ The number of tuples in the relation """
+        return int(self.metadata['numTuples'])
 
-  @staticmethod
-  def _get_name_components(name):
-    components = name.split(':')
-    default_components = ['public', 'adhoc'][:max(3 - len(components), 0)]
-    return default_components + components[:3]
+    @property
+    def metadata(self):
+        """ A JSON dictionary of relation metadata """
+        if self._metadata is None:
+            self._metadata = self.connection.dataset(self.qualified_name)
+        return self._metadata
 
-  @staticmethod
-  def _get_qualified_name(name_or_components):
-    if isinstance(name_or_components, basestring):
-      return MyriaRelation._get_qualified_name(MyriaRelation._get_name_components(name_or_components))
-    else:
-      return dict(izip(('userName', 'programName', 'relationName'), name_or_components[:3]))
+    @property
+    def is_persisted(self):
+        """ Does the relation exist in the Myria database? """
+        try:
+            return bool(self.metadata)
+        except MyriaError:
+            return False
+
+    @staticmethod
+    def _get_name(qualified_name):
+        """ Stringify a list of name components into a valid Myria name """
+        return ':'.join([qualified_name['userName'],
+                         qualified_name['programName'],
+                         qualified_name['relationName']])
+
+    @staticmethod
+    def _get_name_components(name):
+        """ Unstrigify a Myria relation name into a list of components """
+        components = name.split(':')
+        default_components = ['public', 'adhoc'][:max(3 - len(components), 0)]
+        return default_components + components[:3]
+
+    @staticmethod
+    def _get_qualified_name(name_or_components):
+        """ Generate a Myria relation dictionary from a string or list """
+        if isinstance(name_or_components, basestring):
+            return MyriaRelation._get_qualified_name(
+                     MyriaRelation._get_name_components(name_or_components))
+        else:
+            return dict(izip(('userName', 'programName', 'relationName'),
+                             name_or_components[:3]))

--- a/myria/schema.py
+++ b/myria/schema.py
@@ -21,6 +21,12 @@ class MyriaSchema(object):
         self.names = json['columnNames']
         self.types = json['columnTypes']
 
+    def __eq__(self, other):
+        return isinstance(other, MyriaSchema) and self.json == other.json
+
+    def __ne__(self, other):
+        return not self == other
+
     def to_json(self):
         ''' Convert this schema instance to JSON '''
         return {'columnNames': self.names,

--- a/myria/schema.py
+++ b/myria/schema.py
@@ -1,0 +1,9 @@
+class MyriaSchema(object):
+  def __init__(self, json):
+    self.json = json
+    self.names = json['columnNames']
+    self.types = json['columnTypes']
+
+  def toJson(self):
+    return {'columnNames': map(lambda s: s.encode('ascii'), self.names), 
+            'columnTypes': map(lambda s: s.encode('ascii'), self.types)}

--- a/myria/schema.py
+++ b/myria/schema.py
@@ -1,9 +1,12 @@
 class MyriaSchema(object):
-  def __init__(self, json):
-    self.json = json
-    self.names = json['columnNames']
-    self.types = json['columnTypes']
+    """ Represents a schema for a Myria relation """
 
-  def toJson(self):
-    return {'columnNames': map(lambda s: s.encode('ascii'), self.names), 
-            'columnTypes': map(lambda s: s.encode('ascii'), self.types)}
+    def __init__(self, json):
+        self.json = json
+        self.names = json['columnNames']
+        self.types = json['columnTypes']
+
+    def to_json(self):
+        ''' Convert this schema instance to JSON '''
+        return {'columnNames': [n.encode('ascii') for n in self.names],
+                'columnTypes': [t.encode('ascii') for t in self.types]}

--- a/myria/schema.py
+++ b/myria/schema.py
@@ -1,3 +1,6 @@
+""" Higher-level types for interacting with Myria schema """
+
+
 class MyriaSchema(object):
     """ Represents a schema for a Myria relation """
 
@@ -8,5 +11,5 @@ class MyriaSchema(object):
 
     def to_json(self):
         ''' Convert this schema instance to JSON '''
-        return {'columnNames': [n.encode('ascii') for n in self.names],
-                'columnTypes': [t.encode('ascii') for t in self.types]}
+        return {'columnNames': self.names,
+                'columnTypes': self.types}

--- a/myria/schema.py
+++ b/myria/schema.py
@@ -1,10 +1,22 @@
 """ Higher-level types for interacting with Myria schema """
 
+SCHEMA_TYPES = ['INT_TYPE', 'FLOAT_TYPE', 'DOUBLE_TYPE', 'BOOLEAN_TYPE',
+                'STRING_TYPE', 'LONG_TYPE', 'DATETIME_TYPE']
+
 
 class MyriaSchema(object):
     """ Represents a schema for a Myria relation """
 
     def __init__(self, json):
+        if len(json['columnNames']) == 0:
+            raise ValueError('Schema must have at least one attribute.')
+        elif len(json['columnNames']) != len(json['columnTypes']):
+            raise ValueError('Schema must have the same number of attributes '
+                             'and types.')
+        elif any((value not in SCHEMA_TYPES for value in json['columnTypes'])):
+            raise ValueError('One or more schema of the following types are '
+                             'invalid: ' + ', '.join(json['columnTypes']))
+
         self.json = json
         self.names = json['columnNames']
         self.types = json['columnTypes']

--- a/myria/schema.py
+++ b/myria/schema.py
@@ -10,11 +10,11 @@ class MyriaSchema(object):
     def __init__(self, json):
         if len(json['columnNames']) == 0:
             raise ValueError('Schema must have at least one attribute.')
-        elif len(json['columnNames']) != len(json['columnTypes']):
+        if len(json['columnNames']) != len(json['columnTypes']):
             raise ValueError('Schema must have the same number of attributes '
                              'and types.')
-        elif any((value not in SCHEMA_TYPES for value in json['columnTypes'])):
-            raise ValueError('One or more schema of the following types are '
+        if any(value not in SCHEMA_TYPES for value in json['columnTypes']):
+            raise ValueError('One or more of the following types are '
                              'invalid: ' + ', '.join(json['columnTypes']))
 
         self.json = json

--- a/myria/test/test_connection_query.py
+++ b/myria/test/test_connection_query.py
@@ -1,0 +1,97 @@
+from httmock import urlmatch, HTTMock
+import unittest
+from myria import MyriaConnection
+
+
+def query():
+    """Simple empty query"""
+    return {'rawQuery': 'empty',
+            'logicalRa': 'empty',
+            'fragments': []}
+
+
+def query_status(query, query_id=17, status='SUCCESS'):
+    return {'url': 'http://localhost:12345/query/query-%d' % query_id,
+            'queryId': query_id,
+            'rawQuery': query['rawQuery'],
+            'logicalRa': query['rawQuery'],
+            'plan': query,
+            'submitTime': '2014-02-26T15:19:54.505-08:00',
+            'startTime': '2014-02-26T15:19:54.611-08:00',
+            'finishTime': '2014-02-26T15:23:34.189-08:00',
+            'elapsedNanos': 219577567891,
+            'status': status}
+
+
+query_counter = 0
+
+
+@urlmatch(netloc=r'localhost:12345')
+def local_mock(url, request):
+    global query_counter
+    if url.path == '/query' and request.method == 'POST':
+        body = query_status(query(), 17, 'ACCEPTED')
+        headers = {'Location': 'http://localhost:12345/query/query-17'}
+        query_counter = 2
+        return {'status_code': 202, 'content': body, 'headers': headers}
+    elif url.path == '/query/query-17':
+        if query_counter == 0:
+            status = 'SUCCESS'
+            status_code = 201
+        else:
+            status = 'ACCEPTED'
+            status_code = 202
+            query_counter -= 1
+        body = query_status(query(), 17, status)
+        headers = {'Location': 'http://localhost:12345/query/query-17'}
+        return {'status_code': status_code,
+                'content': body,
+                'headers': headers}
+    elif url.path == '/query/validate':
+        return request.body
+    elif url.path == '/query' and request.method == 'GET':
+        body = {'max': 17, 'min': 1,
+                'results': [query_status(query(), 17, 'ACCEPTED'),
+                            query_status(query(), 11, 'SUCCESS')]}
+        return {'status_code': 200, 'content': body}
+
+    return None
+
+
+class TestQuery(unittest.TestCase):
+    def __init__(self, args):
+        with HTTMock(local_mock):
+            self.connection = MyriaConnection(hostname='localhost', port=12345)
+        unittest.TestCase.__init__(self, args)
+
+    def test_submit(self):
+        q = query()
+        with HTTMock(local_mock):
+            status = self.connection.submit_query(q)
+            self.assertEquals(status, query_status(q, status='ACCEPTED'))
+            self.assertEquals(query_counter, 1)
+
+    def test_execute(self):
+        q = query()
+        with HTTMock(local_mock):
+            status = self.connection.execute_query(q)
+            self.assertEquals(status, query_status(q))
+
+    def test_validate(self):
+        q = query()
+        with HTTMock(local_mock):
+            validated = self.connection.validate_query(q)
+            self.assertEquals(validated, q)
+
+    def test_query_status(self):
+        q = query()
+        with HTTMock(local_mock):
+            status = self.connection.get_query_status(17)
+            self.assertEquals(status, query_status(q))
+
+    def x_test_queries(self):
+        with HTTMock(local_mock):
+            result = self.connection.queries()
+            self.assertEquals(result['max'], 17)
+            self.assertEquals(result['min'], 1)
+            self.assertEquals(result['results'][0]['queryId'], 17)

--- a/myria/test/test_plans.py
+++ b/myria/test/test_plans.py
@@ -1,0 +1,60 @@
+import unittest
+import myria.plans
+from myria.schema import MyriaSchema
+
+QUALIFIED_NAME = {'userName': 'public',
+                  'programName': 'adhoc',
+                  'relationName': 'relation'}
+SCHEMA = MyriaSchema({'columnNames': ['column'],
+                      'columnTypes': ['INT_TYPE']})
+WORK = [(0, 'http://input-uri-0'), (1, 'http://input-uri-1')]
+
+
+class TestPlans(unittest.TestCase):
+    def test_parallel_plan(self):
+        text = 'This is logical relational algebra'
+
+        plan = myria.plans.get_parallel_import_plan(SCHEMA,
+                                                    WORK,
+                                                    QUALIFIED_NAME,
+                                                    text=text)
+        self.assertDictContainsSubset({'rawQuery': text,
+                                       'logicalRa': text}, plan)
+        self.assertEquals(len(plan['fragments']), len(WORK))
+
+    def test_worker_assignment(self):
+        plan = myria.plans.get_parallel_import_plan(SCHEMA,
+                                                    WORK,
+                                                    QUALIFIED_NAME)
+
+        fragments = plan['fragments']
+        workers = reduce(lambda a, f: a + f['overrideWorkers'], fragments, [])
+        self.assertListEqual(workers, [worker for worker, _ in WORK])
+
+    def test_scan(self):
+        scan_type = 'UNITTEST-SCAN'
+        scan_metadata = {'metadata': 'foo'}
+        plan = myria.plans.get_parallel_import_plan(
+            SCHEMA, WORK, QUALIFIED_NAME,
+            scan_type=scan_type,
+            scan_metadata=scan_metadata)
+
+        for fragment in plan['fragments']:
+            scan_operator = fragment['operators'][0]
+
+            self.assertEquals(scan_operator['opType'], scan_type)
+            self.assertEquals(scan_operator['metadata'], 'foo')
+
+    def test_insert(self):
+        insert_type = 'UNITTEST-INSERT'
+        insert_metadata = {'metadata': 'bar'}
+        plan = myria.plans.get_parallel_import_plan(
+            SCHEMA, WORK, QUALIFIED_NAME,
+            insert_type=insert_type,
+            insert_metadata=insert_metadata)
+
+        for fragment in plan['fragments']:
+            insert_operator = fragment['operators'][-1]
+
+            self.assertEquals(insert_operator['opType'], insert_type)
+            self.assertEquals(insert_operator['metadata'], 'bar')

--- a/myria/test/test_plans.py
+++ b/myria/test/test_plans.py
@@ -33,11 +33,11 @@ class TestPlans(unittest.TestCase):
 
     def test_scan(self):
         scan_type = 'UNITTEST-SCAN'
-        scan_metadata = {'metadata': 'foo'}
+        scan_parameters = {'metadata': 'foo'}
         plan = myria.plans.get_parallel_import_plan(
             SCHEMA, WORK, QUALIFIED_NAME,
             scan_type=scan_type,
-            scan_metadata=scan_metadata)
+            scan_parameters=scan_parameters)
 
         for fragment in plan['fragments']:
             scan_operator = fragment['operators'][0]
@@ -47,11 +47,11 @@ class TestPlans(unittest.TestCase):
 
     def test_insert(self):
         insert_type = 'UNITTEST-INSERT'
-        insert_metadata = {'metadata': 'bar'}
+        insert_parameters = {'metadata': 'bar'}
         plan = myria.plans.get_parallel_import_plan(
             SCHEMA, WORK, QUALIFIED_NAME,
             insert_type=insert_type,
-            insert_metadata=insert_metadata)
+            insert_parameters=insert_parameters)
 
         for fragment in plan['fragments']:
             insert_operator = fragment['operators'][-1]

--- a/myria/test/test_query.py
+++ b/myria/test/test_query.py
@@ -32,8 +32,7 @@ def get_query_dataset(query_id):
     return [{'relationKey': QUALIFIED_NAME,
              'schema': {
                  'columnNames': ['column'],
-                 'columnTypes': ['INT_TYPE']
-                 },
+                 'columnTypes': ['INT_TYPE']},
              'numTuples': 1,
              'queryId': query_id,
              'created': str(QUERY_TIME)}]

--- a/myria/test/test_query.py
+++ b/myria/test/test_query.py
@@ -36,8 +36,7 @@ def get_query_dataset(query_id):
                  },
              'numTuples': 1,
              'queryId': query_id,
-             'created': str(QUERY_TIME)
-             }]
+             'created': str(QUERY_TIME)}]
 
 
 @urlmatch(netloc=r'localhost:12345')
@@ -74,11 +73,15 @@ def local_mock(url, request):
 
     # Query submission
     elif url.path == '/query':
-        return {'status_code': 201, 'content': '', 'headers': [('Location', '/query-submitted-uri')]}
+        return {'status_code': 201,
+                'content': '',
+                'headers': [('Location', '/query-submitted-uri')]}
 
     elif url.path == '/query-submitted-uri':
         body = json.dumps({'queryId': RUNNING_QUERY_ID})
-        return {'status_code': 201, 'content': body, 'headers': [('Location', '/query-submitted-uri')]}
+        return {'status_code': 201,
+                'content': body,
+                'headers': [('Location', '/query-submitted-uri')]}
 
     return None
 
@@ -166,8 +169,11 @@ class TestQuery(unittest.TestCase):
 
     def test_parallel_import(self):
         with HTTMock(local_mock):
-            schema = MyriaSchema({'columnNames': ['column'], 'columnTypes': ['INT_TYPE']})
-            relation = MyriaRelation(FULL_NAME, schema=schema, connection=self.connection)
+            schema = MyriaSchema({'columnNames': ['column'],
+                                  'columnTypes': ['INT_TYPE']})
+            relation = MyriaRelation(FULL_NAME,
+                                     schema=schema,
+                                     connection=self.connection)
             work = [('http://input-uri-0', 0), ('http://input-uri-1', 1)]
 
             query = MyriaQuery.parallel_import(relation, work)

--- a/myria/test/test_relation.py
+++ b/myria/test/test_relation.py
@@ -1,0 +1,106 @@
+from httmock import urlmatch, HTTMock
+from datetime import datetime
+import unittest
+from myria.connection import MyriaConnection
+from myria.relation import MyriaRelation
+from myria.schema import MyriaSchema
+
+
+RELATION_NAME = 'relation'
+FULL_NAME = 'public:adhoc:' + RELATION_NAME
+QUALIFIED_NAME = {'userName': 'public',
+                  'programName': 'adhoc',
+                  'relationName': RELATION_NAME}
+NAME_COMPONENTS = ['public', 'adhoc', RELATION_NAME]
+SCHEMA = {'columnNames': ['column'], 'columnTypes': ['INT_TYPE']}
+CREATED_DATE = datetime(1900, 1, 2, 3, 4)
+TUPLES = [[1], [2], [3], [4], [5]]
+TOTAL_TUPLES = len(TUPLES)
+
+
+def get_uri(name):
+    return '/dataset/user-{}/program-{}/relation-{}'.format(
+               'public', 'adhoc', name)
+
+
+@urlmatch(netloc=r'localhost:12345')
+def local_mock(url, request):
+    # Relation metadata
+    if url.path == get_uri(RELATION_NAME):
+        body = {'numTuples': TOTAL_TUPLES,
+                'schema': SCHEMA,
+                'created': str(CREATED_DATE)}
+        return {'status_code': 200, 'content': body}
+
+    # Relation download
+    if url.path == get_uri(RELATION_NAME) + '/data':
+        body = str(TUPLES)
+        return {'status_code': 200, 'content': body}
+
+    # Relation not found in database
+    elif get_uri('NOTFOUND') in url.path:
+        return {'status_code': 404}
+
+    return None
+
+
+class TestRelation(unittest.TestCase):
+    def __init__(self, args):
+        with HTTMock(local_mock):
+            self.connection = MyriaConnection(hostname='localhost', port=12345)
+        super(TestRelation, self).__init__(args)
+
+    def test_name(self):
+        relation = MyriaRelation(FULL_NAME, connection=self.connection)
+        self.assertEquals(relation.name, FULL_NAME)
+        self.assertDictEqual(relation.qualified_name, QUALIFIED_NAME)
+        self.assertListEqual(relation.components, NAME_COMPONENTS)
+
+    def test_unpersisted_relation(self):
+        with HTTMock(local_mock):
+            self.assertFalse(MyriaRelation(
+                'public:adhoc:NOTFOUND',
+                connection=self.connection).is_persisted)
+
+    def test_persisted_relation(self):
+        with HTTMock(local_mock):
+            self.assertTrue(MyriaRelation(
+                FULL_NAME, connection=self.connection).is_persisted)
+
+    def test_persisted_with_schema(self):
+        with HTTMock(local_mock):
+            self.assertRaises(ValueError,
+                              MyriaRelation,
+                              FULL_NAME,
+                              connection=self.connection,
+                              schema=MyriaSchema(SCHEMA))
+
+    def test_persisted_schema(self):
+        with HTTMock(local_mock):
+            relation = MyriaRelation(FULL_NAME, connection=self.connection)
+            self.assertDictEqual(relation.schema.to_json(), SCHEMA)
+
+    def test_created_date(self):
+        with HTTMock(local_mock):
+            relation = MyriaRelation(FULL_NAME, connection=self.connection)
+
+            self.assertEquals(relation.created_date, CREATED_DATE)
+
+    def test_len(self):
+        with HTTMock(local_mock):
+            relation = MyriaRelation(FULL_NAME, connection=self.connection)
+
+            self.assertEquals(len(relation), TOTAL_TUPLES)
+
+    def test_json_download(self):
+        with HTTMock(local_mock):
+            relation = MyriaRelation(FULL_NAME, connection=self.connection)
+
+            self.assertListEqual(relation.to_json(), TUPLES)
+
+    def test_unpersisted_json_download(self):
+        with HTTMock(local_mock):
+            relation = MyriaRelation('public:adhoc:NOTFOUND',
+                                     connection=self.connection)
+
+            self.assertIsNone(relation.to_json(), None)

--- a/myria/test/test_relation.py
+++ b/myria/test/test_relation.py
@@ -81,11 +81,26 @@ class TestRelation(unittest.TestCase):
 
     def test_persisted_with_schema(self):
         with HTTMock(local_mock):
+            self.assertIsInstance(MyriaRelation(FULL_NAME,
+                                                connection=self.connection,
+                                                schema=MyriaSchema(SCHEMA)),
+                                  MyriaRelation)
+
+            different_name = {'columnNames': ['foo'],
+                              'columnTypes': ['INT_TYPE']}
             self.assertRaises(ValueError,
                               MyriaRelation,
                               FULL_NAME,
                               connection=self.connection,
-                              schema=MyriaSchema(SCHEMA))
+                              schema=MyriaSchema(different_name))
+
+            different_type = {'columnNames': ['column'],
+                              'columnTypes': ['STRING_TYPE']}
+            self.assertRaises(ValueError,
+                              MyriaRelation,
+                              FULL_NAME,
+                              connection=self.connection,
+                              schema=MyriaSchema(different_type))
 
     def test_persisted_schema(self):
         with HTTMock(local_mock):

--- a/myria/test/test_relation.py
+++ b/myria/test/test_relation.py
@@ -115,4 +115,4 @@ class TestRelation(unittest.TestCase):
             relation = MyriaRelation('public:adhoc:NOTFOUND',
                                      connection=self.connection)
 
-            self.assertIsNone(relation.to_json(), None)
+            self.assertEquals(relation.to_json(), [])

--- a/myria/test/test_relation.py
+++ b/myria/test/test_relation.py
@@ -20,7 +20,7 @@ TOTAL_TUPLES = len(TUPLES)
 
 def get_uri(name):
     return '/dataset/user-{}/program-{}/relation-{}'.format(
-               'public', 'adhoc', name)
+        'public', 'adhoc', name)
 
 
 @urlmatch(netloc=r'localhost:12345')
@@ -50,11 +50,23 @@ class TestRelation(unittest.TestCase):
             self.connection = MyriaConnection(hostname='localhost', port=12345)
         super(TestRelation, self).__init__(args)
 
+    def test_connection(self):
+        with HTTMock(local_mock):
+            relation = MyriaRelation(FULL_NAME, connection=self.connection)
+            self.assertEquals(relation.connection, self.connection)
+
+            relation = MyriaRelation(FULL_NAME)
+            self.assertEquals(relation.connection,
+                              MyriaRelation.DefaultConnection)
+
     def test_name(self):
-        relation = MyriaRelation(FULL_NAME, connection=self.connection)
-        self.assertEquals(relation.name, FULL_NAME)
-        self.assertDictEqual(relation.qualified_name, QUALIFIED_NAME)
-        self.assertListEqual(relation.components, NAME_COMPONENTS)
+        with HTTMock(local_mock):
+            relation = MyriaRelation(FULL_NAME, connection=self.connection)
+            self.assertEquals(relation.name, FULL_NAME)
+            self.assertDictEqual(relation.qualified_name, QUALIFIED_NAME)
+            self.assertListEqual(relation.components, NAME_COMPONENTS)
+            self.assertEquals(relation._get_name(relation.qualified_name),
+                              FULL_NAME)
 
     def test_unpersisted_relation(self):
         with HTTMock(local_mock):

--- a/myria/test/test_schema.py
+++ b/myria/test/test_schema.py
@@ -1,0 +1,33 @@
+import unittest
+from myria.schema import MyriaSchema
+
+
+class TestQuery(unittest.TestCase):
+    def test_empty(self):
+        empty_schema = {'columnNames': [], 'columnTypes': []}
+        self.assertRaises(ValueError, MyriaSchema, empty_schema)
+
+    def test_argument_lengths(self):
+        attribute_mismatch = {'columnNames': ['column1'], 'columnTypes': []}
+        self.assertRaises(ValueError, MyriaSchema, attribute_mismatch)
+
+        type_mismatch = {'columnNames': [], 'columnTypes': ['INT_TYPE']}
+        self.assertRaises(ValueError, MyriaSchema, type_mismatch)
+
+    def test_invalid_types(self):
+        invalid_type = {'columnNames': ['foo'], 'columnTypes': ['FOO_TYPE']}
+        self.assertRaises(ValueError, MyriaSchema, invalid_type)
+
+    def test_names(self):
+        names = ['column1']
+        schema = {'columnNames': names, 'columnTypes': ['INT_TYPE']}
+        self.assertListEqual(names, MyriaSchema(schema).names)
+
+    def test_types(self):
+        types = ['INT_TYPE']
+        schema = {'columnNames': ['foo'], 'columnTypes': types}
+        self.assertListEqual(types, MyriaSchema(schema).types)
+
+    def test_json(self):
+        schema = {'columnNames': ['foo'], 'columnTypes': ['INT_TYPE']}
+        self.assertDictEqual(schema, MyriaSchema(schema).to_json())

--- a/myria/test/test_schema.py
+++ b/myria/test/test_schema.py
@@ -2,7 +2,7 @@ import unittest
 from myria.schema import MyriaSchema
 
 
-class TestQuery(unittest.TestCase):
+class TestSchema(unittest.TestCase):
     def test_empty(self):
         empty_schema = {'columnNames': [], 'columnTypes': []}
         self.assertRaises(ValueError, MyriaSchema, empty_schema)


### PR DESCRIPTION
Per our discussion today on introducing higher-level entities in Myria-Python.  Also a result of discussion in #30.

These classes are pretty bare-bones and expose most of the low-hanging fruit.  The main additional feature is the parallel_import function on the MyriaQuery class, which accepts a set of (up to) n URIs given n workers.  This may fail with >n URIs -- not sure.
