### PR TITLE
Add execution URL to MyriaConnection constructor

### DIFF
--- a/myria/connection.py
+++ b/myria/connection.py
@@ -77,8 +77,8 @@ class MyriaConnection(object):
         if rest_url is not None:
             url = urlparse(rest_url)
             hostname = url.hostname
-            port = url.port
             ssl = url.scheme == "https"
+            port = url.port or (443 if ssl else 80)
 
         if ssl:
             uri_scheme = "https"


### PR DESCRIPTION
This change will be a useful prerequisite for the IPython extension, which needs a convenient way to create a connection to both the REST API (for query metadata and results) and Myria-Web (to execute programs).

As more functionality is hidden behind the webserver, we can gradually transition to using this new URL exclusively.