### PR TITLE
Fix parallel import myria-python

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -173,7 +173,8 @@ work = [(1, 'https://s3-us-west-2.amazonaws.com/uwdb/sampleData/TwitterK-part1.c
         (2, 'https://s3-us-west-2.amazonaws.com/uwdb/sampleData/TwitterK-part2.csv')]
 
 # Upload the data
-query = MyriaQuery.parallel_import(relation=relation, work=work)
+query = MyriaQuery.parallel_import(relation=relation, work=work, scan_type='TupleSource',
+                                   scan_parameters={'readerType': 'CSV'})
 print query.status
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -172,9 +172,9 @@ relation = MyriaRelation('parallelLoad', connection=connection, schema=schema)
 work = [(1, 'https://s3-us-west-2.amazonaws.com/uwdb/sampleData/TwitterK-part1.csv'),
         (2, 'https://s3-us-west-2.amazonaws.com/uwdb/sampleData/TwitterK-part2.csv')]
 
-# Upload the data
-query = MyriaQuery.parallel_import(relation=relation, work=work, scan_type='TupleSource',
-                                   scan_parameters={'readerType': 'CSV'})
+# Upload the data (CSV is the default upload type)
+query = query = MyriaQuery.parallel_import(relation=relation, work=work)
+
 print query.status
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -173,7 +173,7 @@ work = [(1, 'https://s3-us-west-2.amazonaws.com/uwdb/sampleData/TwitterK-part1.c
         (2, 'https://s3-us-west-2.amazonaws.com/uwdb/sampleData/TwitterK-part2.csv')]
 
 # Upload the data (CSV is the default upload type)
-query = query = MyriaQuery.parallel_import(relation=relation, work=work)
+query = MyriaQuery.parallel_import(relation=relation, work=work)
 
 print query.status
 ```

--- a/myria/plans.py
+++ b/myria/plans.py
@@ -2,9 +2,9 @@
 
 from functools import partial
 
-
 DEFAULT_SCAN_TYPE = 'FileScan'
 DEFAULT_INSERT_TYPE = 'DbInsert'
+DEFAULT_READER_TYPE = 'CSV'
 
 
 def get_parallel_import_plan(schema, work, relation, text='',
@@ -44,10 +44,11 @@ def _get_parallel_import_fragment(taskid, schema, relation,
         'opId': __increment(taskid),
         'opType': scan_type or DEFAULT_SCAN_TYPE,
 
-        'schema': schema.to_dict(),
+        'reader': {'schema': schema.to_dict(),
+                   'readerType': DEFAULT_READER_TYPE},
         'source': datasource
     }
-    scan.update(scan_parameters or {})
+    scan['reader'].update(scan_parameters or {})
 
     insert = {
         'opId': __increment(taskid),

--- a/myria/plans.py
+++ b/myria/plans.py
@@ -2,9 +2,8 @@
 
 from functools import partial
 
-DEFAULT_SCAN_TYPE = 'FileScan'
+DEFAULT_SCAN_TYPE = {'readerType': 'CSV'}
 DEFAULT_INSERT_TYPE = 'DbInsert'
-DEFAULT_READER_TYPE = 'CSV'
 
 
 def get_parallel_import_plan(schema, work, relation, text='',
@@ -40,15 +39,16 @@ def _get_parallel_import_fragment(taskid, schema, relation,
     worker_id = assignment[0]
     datasource = assignment[1]
 
+    scan_type = scan_type or DEFAULT_SCAN_TYPE
+    scan_type.update({'schema': schema.to_dict()})
     scan = {
         'opId': __increment(taskid),
-        'opType': scan_type or DEFAULT_SCAN_TYPE,
+        'opType': 'TupleSource',
 
-        'reader': {'schema': schema.to_dict(),
-                   'readerType': DEFAULT_READER_TYPE},
+        'reader': scan_type,
         'source': datasource
     }
-    scan['reader'].update(scan_parameters or {})
+    scan.update(scan_parameters or {})
 
     insert = {
         'opId': __increment(taskid),

--- a/myria/query.py
+++ b/myria/query.py
@@ -61,8 +61,9 @@ class MyriaQuery(object):
               file, http, hdfs) and any combination may be assigned to workers.
               For local file URIs (file://foo/bar), the file is assumed to
               be local (or locally accessible).
-        scan_type: Something like "CSV"
-        scan_parameters: Options to the Reader, such as {"skip": 1}.
+        scan_type: Reader parameters, e.g., {'readerType': 'CSV', "skip": 1}.
+                Schema is inserted into this.
+        scan_parameters: Additional options to the TupleSource operator.
         """
         return MyriaQuery.submit_plan(
             myria.plans.get_parallel_import_plan(

--- a/myria/query.py
+++ b/myria/query.py
@@ -61,6 +61,8 @@ class MyriaQuery(object):
               file, http, hdfs) and any combination may be assigned to workers.
               For local file URIs (file://foo/bar), the file is assumed to
               be local (or locally accessible).
+        scan_type: Something like "CSV"
+        scan_parameters: Options to the Reader, such as {"skip": 1}.
         """
         return MyriaQuery.submit_plan(
             myria.plans.get_parallel_import_plan(


### PR DESCRIPTION
This is for `MyriaQuery.parallel_import`. It was using an old FileScan JSON syntax.

* Used the options `scan_type` and `scan_parameters` to specify the reader type and its options.
* Updated example in the documentation.