### PR TITLE
Better ambient connection support for UDFs

### DIFF
--- a/myria/test/test_fluent.py
+++ b/myria/test/test_fluent.py
@@ -326,6 +326,8 @@ class TestFluent(unittest.TestCase):
     def test_extension_method(self):
         server_state = {}
         with HTTMock(create_mock(server_state)):
+            # Prevent ambient UDF registration
+            MyriaRelation.DefaultConnection = None
             relation = MyriaRelation(FULL_NAME, connection=self.connection)
 
             @myria_function(name='my_udf', output_type=BOOLEAN_TYPE)
@@ -354,6 +356,8 @@ class TestFluent(unittest.TestCase):
     def test_multivalued_extension_method(self):
         server_state = {}
         with HTTMock(create_mock(server_state)):
+            # Prevent ambient UDF registration
+            MyriaRelation.DefaultConnection = None
             relation = MyriaRelation(FULL_NAME, connection=self.connection)
 
             @myria_function(name='my_udf', output_type=BOOLEAN_TYPE,

--- a/myria/test/test_relation.py
+++ b/myria/test/test_relation.py
@@ -59,6 +59,7 @@ class TestRelation(unittest.TestCase):
             relation = MyriaRelation(FULL_NAME, connection=self.connection)
             self.assertEquals(relation.connection, self.connection)
 
+            MyriaRelation.DefaultConnection = self.connection
             relation = MyriaRelation(FULL_NAME)
             self.assertEquals(relation.connection,
                               MyriaRelation.DefaultConnection)

--- a/myria/udf.py
+++ b/myria/udf.py
@@ -15,11 +15,13 @@ def myria_function(name=None, output_type=STRING_TYPE, multivalued=False,
                    connection=None):
     def decorator(f):
         from myria import MyriaFluentQuery
+        from myria import MyriaRelation
+        udf_connection = connection or MyriaRelation.DefaultConnection
         udf_name = name or f.__name__
 
-        if connection:
-            MyriaPythonFunction(f, output_type, name,
-                                multivalued, connection).register()
+        if udf_connection:
+            MyriaPythonFunction(f, output_type, udf_name,
+                                multivalued, udf_connection).register()
 
         setattr(
             MyriaFluentQuery,
@@ -36,7 +38,9 @@ class MyriaFunction(object):
     _cache = {}
 
     @classmethod
-    def get_all(cls, connection):
+    def get_all(cls, connection=None):
+        from myria import MyriaRelation
+        connection = connection or MyriaRelation.DefaultConnection
         if connection.execution_url not in cls._cache:
             cls._cache[connection.execution_url] = [
                 MyriaPythonFunction.from_dict(udf, connection)
@@ -48,7 +52,9 @@ class MyriaFunction(object):
         return cls._cache[connection.execution_url]
 
     @classmethod
-    def get(cls, name, connection):
+    def get(cls, name, connection=None):
+        from myria import MyriaRelation
+        connection = connection or MyriaRelation.DefaultConnection
         return next((f for f in cls.get_all(connection) if f.name == name),
                     None)
 


### PR DESCRIPTION
* Falls back to ambient connection in `get`, `get_all`, and the UDF decorator
* Fixes bug where the function name wasn't being used when `name` wasn't specified